### PR TITLE
chore: use theme overrides to set labelText for Hero Item in hero list

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -7,7 +7,12 @@ import { makeIcon } from '@apollosproject/ui-kit';
 const THEME = {
   colors: { primary: '#C86600', secondary: '#C86600' },
   typography: {},
-  overrides: { 'ui-kit.ContentTitles': { onPressLike: 0, onPressShare: 0 } },
+  overrides: {
+    'ui-kit.ContentTitles': { onPressLike: 0, onPressShare: 0 },
+    HeroItemComponent: {
+      labelText: 'Latest Episode',
+    },
+  },
 };
 
 const ICONS = {


### PR DESCRIPTION
### **The Purpose of This PR** 
To set "**Latest Episode**" as the label on the hero-list's hero-item found in the "**Recently Added**" tab. 

### **Notes** 
The color and weight of the label, both before and after the override, did not and do not match the reference image but I'm not sure if these should be addressed in this specific PR.

### **Before Override**
<img width="470" alt="Screen Shot 2022-04-19 at 10 33 48 AM" src="https://user-images.githubusercontent.com/19194337/164028691-b5d1a785-beba-4367-9494-3f51e684cdef.png">

### **Reference Image From Basecamp**
<img width="498" alt="Screen Shot 2022-03-31 at 2 36 01 PM" src="https://user-images.githubusercontent.com/19194337/164029832-dcc889e6-ae97-4ebd-8578-68dbfff2c3c7.png">

### **After Override**
<img width="470" alt="Screen Shot 2022-04-19 at 10 32 48 AM" src="https://user-images.githubusercontent.com/19194337/164030472-dd866064-1385-45e9-afc7-bbbccc501f98.png">
