### PR TITLE
chore: add autoplay override

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -12,6 +12,9 @@ const THEME = {
     HeroItemComponent: {
       labelText: 'Latest Episode',
     },
+    'ui-connected.NodeSingleConnected': () => () => ({
+      autoplay: true,
+    }),
   },
 };
 

--- a/theme.js
+++ b/theme.js
@@ -12,7 +12,7 @@ const THEME = {
     HeroItemComponent: {
       labelText: 'Latest Episode',
     },
-    'ui-connected.NodeSingleConnected': () => () => ({
+    'ui-media-player.ApollosPlayerContainer': () => () => ({
       autoplay: true,
     }),
   },


### PR DESCRIPTION
### **The Purpose of this PR** 
Adds an override to set autoplay to true.

### **override for ui-connected.NodeSingleConnected**
```
'ui-connected.NodeSingleConnected': () => () => ({
    autoplay: true,
}),
```

_Note_: This will only work if the autoplay prop has been added to ApollosPlayerContainer in core via this [PR](https://github.com/ApollosProject/apollos-apps/pull/2480)