### PR TITLE
chore: bump ui-media-player from 2.45.0 to 3.3.1-canary.8

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -298,7 +298,7 @@ PODS:
   - React-jsinspector (0.67.2)
   - React-logger (0.67.2):
     - glog
-  - react-native-apollos-player (2.45.0):
+  - "react-native-apollos-player (3.3.1-canary.8+27aa0a945)":
     - React
   - react-native-config (0.11.7):
     - React
@@ -725,7 +725,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 52beb652bbc61201bd70cbe4f0b8edb607e8da4f
   React-jsinspector: 595f76eba2176ebd8817a1fffd47b84fbdab9383
   React-logger: 23de8ea0f44fa00ee77e96060273225607fd4d78
-  react-native-apollos-player: 923e427b199f91106a713f5fc4212127fa815013
+  react-native-apollos-player: be9ec8a8fb786598920609a0b5a1548ebd574084
   react-native-config: 55548054279d92e0e4566ea15a8b9b81028ec342
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-geolocation-service: 7c9436da6dfdecd9526c62eac62ea2bc3f0cc8ea

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@apollosproject/ui-htmlview": "^2.43.2-canary.10",
     "@apollosproject/ui-kit": "^2.45.0",
     "@apollosproject/ui-mapview": "^2.43.1",
-    "@apollosproject/ui-media-player": "^2.45.0",
+    "@apollosproject/ui-media-player": "^3.3.1-canary.8",
     "@apollosproject/ui-notifications": "^2.43.1",
     "@apollosproject/ui-onboarding": "^2.43.1",
     "@apollosproject/ui-passes": "^2.43.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,10 +106,10 @@
   dependencies:
     "@apollo/client" "3.3.20"
 
-"@apollosproject/ui-media-player@^2.45.0":
-  version "2.45.0"
-  resolved "https://registry.npmjs.org/@apollosproject/ui-media-player/-/ui-media-player-2.45.0.tgz"
-  integrity sha512-F0mWm+tIboXEt6tk9Ca4kG28Bz6PCCxnS2huY7Ito+PFD4ZYtQTdJJWf/APM5Zm3Ru7rJmhGz8X8dg0yIlySzA==
+"@apollosproject/ui-media-player@^3.3.1-canary.8":
+  version "3.3.1-canary.8"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-media-player/-/ui-media-player-3.3.1-canary.8.tgz#ef74cefd010b538e97a5efba60d8d60312674628"
+  integrity sha512-vhL+i02r1giZij2S0fbe9tCMC8B7CWaenFt8+0hEWwLoch20tZYKjwaVez3NS2c02hJsFSZg0jry3wg0T3SZUA==
   dependencies:
     "@types/color" "^3.0.1"
     color "^3.1.2"


### PR DESCRIPTION
### **The Purpose of this PR** 
To bump the version of @apollosproject/ui-media-player from 2.45.0 to 3.3.1-canary.8 so that we may override the apollos player container override.

### **Demo** 
https://user-images.githubusercontent.com/19194337/165296069-66c0cd31-5572-4cc0-ab54-d509978e662e.mov


