### PR TITLE
Update Supported Screen Sizes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.apollos.crossroads_kids_club">
+    <supports-screens android:smallScreens="true"
+    android:normalScreens="true"
+    android:largeScreens="false"
+    android:xlargeScreens="false"/>
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
In order to allow for 2 different applications to exist on android (one for tv targets and 1 for mobile targets), we need to limit the allowed screen sizes of the mobile app to _only_ Small and Normal. The tv project includes the inverse of this (only allow Large and Extra Large)